### PR TITLE
Adds functionality to handle multiple MC lists

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 ## Version History
 
+**5.1.0**
+
+-   Adds ability to override default Mailchimp endpoint with a custom one
+
 **5.0.1**
 
 -   Adds eslint and prettier

--- a/README.md
+++ b/README.md
@@ -1,50 +1,81 @@
 ## Subscribe emails to your Mailchimp list
-This Gatsby plugin helps you subscribe new email addresses to a Mailchimp email list.  Mailchimp does not provide much direction on making clientside requests so the setup to achieve this with a static website (i.e. Gatsby) can be cumbersome.
 
+This Gatsby plugin helps you subscribe new email addresses to a Mailchimp email list. Mailchimp does
+not provide much direction on making clientside requests so the setup to achieve this with a static
+website (i.e. Gatsby) can be cumbersome.
+
+## 🍾 We now support multiple Mailchimp lists! 🎉
+
+See below for details.
 
 ## How It Works Under The Hood
-What this plugin does is scan your `gatsby-config` for your MC settings.  Then, once you import and invoke the `addToMailchimp` method in your React component, it makes a jsonp request of the email/attributes to MC's server using your settings.
 
+First we scan your `gatsby-config` for your MC endpoint. Then, once you import and invoke the
+`addToMailchimp` method in your React component, it makes a jsonp request to your endpoint with the
+email, attributes, and any group fields you include in the request.
+
+## Getting Started
+
+There are three steps involved to getting started:
+
+1. add this plugin to your repo
+
+    - In the root directory of your Gatsby project, run the following command in your terminal:
+
+    ```
+    # npm
+    $ npm install gatsby-plugin-mailchimp
+
+    # yarn
+    $ yarn add gatsby-plugin-mailchimp
+    ```
+
+2. add your Mailchimp endpoint to your `gatsby-config.js` file (see below for instructions)
+3. import & invoke the `addToMailchimp` method exported by this plugin
 
 ## Using Gatsby v1?
-If you are still on Gatsby v1.x, you need to use an old version of this plugin.  There were a lot of changes made in Gatsby v2 that will cause this plugin so make sure to use the correct version of this plugin if you are still on Gatsby v1.
+
+If you are still on Gatsby v1.x, you need to use an old version of this plugin. There were a lot of
+changes made in Gatsby v2 that will cause this plugin to break so make sure to use the correct
+version of this plugin if you are still on Gatsby v1.
 
 We no longer maintain this version.
 
 Simply update your `package.json` to:
-```javascript
-"gatsby-plugin-mailchimp": "https://github.com/benjaminhoffman/gatsby-plugin-mailchimp.git#gatsby-v1",
-```
 
-## Getting Started
-There are three steps involved to getting started:
+    ```
+    # npm
+    $ npm install https://github.com/benjaminhoffman/gatsby-plugin-mailchimp.git#gatsby-v1
 
-1. add this plugin to your repo
-    - In the root directory of your Gatsby project, run the following command in your terminal: `$ yarn add gatsby-plugin-mailchimp`
-    - or if using Gatsby v2: `$ yarn add https://github.com/benjaminhoffman/gatsby-plugin-mailchimp.git#gatsby-v2`
-2. include your Mailchimp settings in your `gatsby-config.js` file
-3. import the `addToMailchimp` function to subscribe emails to your MC list
-
-
+    # yarn
+    $ yarn add https://github.com/benjaminhoffman/gatsby-plugin-mailchimp.git#gatsby-v1
+    ```
 
 ## Gatsby Config Instructions
-You need to provide this plugin with your Mailchimp account and list details in order for it to know which endpoint to save the email address to.  Follow these directions:
+
+You need to provide this plugin with your Mailchimp account and list details in order for it to know
+which endpoint to save the email address to. Follow these directions:
 
 In your `gatsby-config.js` file, add the following code to the plugin section:
+
 ```javascript
 plugins: [
-  ...
-  {
-    resolve: 'gatsby-plugin-mailchimp',
-    options: {
-      endpoint: '', // see instructions section below
+    ...{
+        resolve: 'gatsby-plugin-mailchimp',
+        options: {
+            endpoint: '', // add your MC list endpoint here; see instructions below
+        },
     },
-  },
-]
+];
 ```
 
-
 ### Mailchimp Endpoint
+
+Your Mailchimp endpoint will look something like this:
+_https://example.us10.list-manage.com/subscribe/post?u=b9ef2fdd3edofhec04ba9b930&amp;id=3l948gkt1d_
+
+Here is how you can locate your Mailchimp endpoint.
+
 1. Login to your Mailchimp account
 2. Click "Lists" tab at the top
 3. Locate the Mailchimp list you want to save email addresses to
@@ -55,20 +86,28 @@ plugins: [
 ![screenshot of how to locate your Mailchimp `u` settings](https://raw.githubusercontent.com/benjaminhoffman/gatsby-plugin-mailchimp/master/img/mailchimp_list.png)
 
 7. Scroll down to the section with all the HTML code
-8. Locate the HTML form element.  Copy the entire URL listed under the form "action" attribute*
+8. Locate the HTML form element. Copy the entire URL listed under the form "action" attribute\*
 9. Paste that URL into your `gatsby-config`ʼs `option.endpoint` field
-
-* Usually this URL value will look something like: _https://example.us10.list-manage.com/subscribe/post?u=b9ef2fdd3edofhec04ba9b930&amp;id=3l948gkt1d_
 
 ![screenshot of how to copy/paste your list settings URL](https://raw.githubusercontent.com/benjaminhoffman/gatsby-plugin-mailchimp/master/img/mailchimp_form_action.png)
 
 ... that's all!
 
-
 ## Gatsby Import Plugin Instructions
-This plugin exports one method -- `addToMailchimp` -- that accepts two params: `email` and `listFields`, where `email` is a valid email string and `listFields` is an object of attributes youʼd like to save with the email address.  More detailed instructions below.
 
-Navigate to the file where you collect email addresses (ie, the file you want to import this plugin into).  When a user submits a form and includes at least their email address, invoke the `addToMailchimp` method like you would any other method.  Here is an example:
+This plugin exports one method -- `addToMailchimp` -- that accepts one required argument (`email`)
+and two optional fields (`fields` and `endpointOverride`).
+
+-   `email` is a valid email string
+-   `fields` is an object of attributes youʼd like to save with the email address. More detailed
+    instructions below.
+-   `endpointOverride` is if you want to pass in a custom MC endpoint (one that is different than
+    the one listed in your config file. See below for details)
+
+Navigate to the file where you collect email addresses (ie, the file you want to import this plugin
+into). When a user submits a form and includes at least their email address, invoke the
+`addToMailchimp` method like you would any other method. Here is an example:
+
 ```javascript
 import addToMailchimp from 'gatsby-plugin-mailchimp'
 ...
@@ -116,17 +155,24 @@ export default class MyGatsbyComponent extends React.Component {
 ```
 
 ## Returns
-This plugin returns a promise that resolves to the object that is returned by Mailchimpʼs API.  The Mailchimp API will always return a status of 200.  In order to know if your submission was a success or error, you must read the returned object, which has a `result` and `msg` property:
+
+This plugin returns a promise that resolves to the object that is returned by Mailchimpʼs API. The
+Mailchimp API will always return a status of 200. In order to know if your submission was a success
+or error, you must read the returned object, which has a `result` and `msg` property:
+
 ```javascript
 {
-  result: string // either `success` or `error` (helpful to use this key to update your state)
-  msg: string // a user-friendly message indicating details of your submissions (usually something like "thanks for subscribing!" or "this email has already been added")
+    result: string; // either `success` or `error` (helpful to use this key to update your state)
+    msg: string; // a user-friendly message indicating details of your submissions (usually something like "thanks for subscribing!" or "this email has already been added")
 }
 ```
 
-
 ## Mailchimp List Fields
-Sometimes you want to send to Mailchimp more than just an email address.  Itʼs very common to also send a first name, last name, pathname, etc.  Honestly, you can send whatever you want to store alongside the email address.  Instructions below on how to create new list fields but once youʼve set them up in Mailchimp, you send them alongside the email like this:
+
+Sometimes you want to send to Mailchimp more than just an email address. Itʼs very common to also
+send a first name, last name, pathname, etc. Honestly, you can send whatever you want to store
+alongside the email address. Instructions below on how to create new list fields but once youʼve set
+them up in Mailchimp, you send them alongside the email like this:
 
 ```javascript
 addToMailchimp('email@example.com', {
@@ -138,25 +184,33 @@ addToMailchimp('email@example.com', {
 ```
 
 ## Mailchimp Groups
-Mailchimp offers the concept of list groups.  It's a bit tricky to implement here because you _must_ use the exact key and value as defined in your MC Embedded Form for those fields.
 
-To add these you must go back to your "Embedded Forms" (where you got your endpoint from) and find the form field that represents the group you want to add this user to.  Next, copy the name and use that as your key in the `addToMailchimp` field param.  The name field will have weird values like `group[21265][2]` or `group[21269]`.
+Mailchimp offers the concept of list groups. It's a bit tricky to implement here because you _must_
+use the exact key and value as defined in your MC Embedded Form for those fields.
 
-Similarly, the `input` field `value` must also be the same as you see.  This means you must either set the name and value fields manually in your form or keep a mapping in your JS file.
+To add these you must go back to your "Embedded Forms" (where you got your endpoint from) and find
+the form field that represents the group you want to add this user to. Next, copy the name and use
+that as your key in the `addToMailchimp` field param. The name field will have weird values like
+`group[21265][2]` or `group[21269]`.
 
-Why do we need to use these weird structure for name and value field?  Because this is what Mailchimp expects. 🤷🏽‍♂️
+Similarly, the `input` field `value` must also be the same as you see. This means you must either
+set the name and value fields manually in your form or keep a mapping in your JS file.
+
+Why do we need to use these weird structure for name and value field? Because this is what Mailchimp
+expects. 🤷🏽‍♂️
 
 For example, here is a screenshot of what this looks like:
 
 ![screenshot of Mailchimp Groups](https://raw.githubusercontent.com/benjaminhoffman/gatsby-plugin-mailchimp/master/img/mc_groups.png)
 
-And the code would be: 
+And the code would be:
+
 ```
 # HTML
 /*
   Here we chose to name the input field the same as what's in
   our embedded form.  But you can name it whatever you want and keep
-  a field name map in your JS. Mailchimp expects the name and value 
+  a field name map in your JS. Mailchimp expects the name and value
   to match what's in its Embedded Form
 */
 <input value="2" name="group[21265][2]">
@@ -173,27 +227,54 @@ addToMailchimp('email@example.com', {
 
 See here for [thread](https://github.com/benjaminhoffman/gatsby-plugin-mailchimp/pull/31).
 
+## Multiple Mailchimp lists
 
+Many people asked for the ability to send users to different Mailchimp lists. We added that
+capability! How we added this capability without a breaking change is by allowing you to _override_
+the endpoint that's listed in your `gatsby-config.js` file. When you invoke `addToMailchimp`, pass
+in a third argument of the list you'd like to subscribe this email address to. That will override
+the default one listed in your config.
+
+```javascript
+addToMailchimp(
+    'ben@gatsby-plugin-mailchimp.com',
+    {
+        /* list fields here*/
+    },
+    'https://example.us10.list-manage.com/subscribe/post?u=b9ef2fdd3ed',
+);
+```
 
 ## Example
+
 See directory in this repo called `/examples`.
 
-Also, here are some helpful links:
-- Add Mailchimp settings via gatsby-config ([link](https://github.com/gatsbyjs/gatsby/blob/master/www/gatsby-config.js#L175-L180))
-- Use React state to show success, error, and sending messages in the UI ([link](https://github.com/gatsbyjs/gatsby/blob/master/www/src/components/email-capture-form.js#L45-L84))
-
-
 ## Gotchas
-1. *email address*: pass in the email as normal (ie, `you@gmail.com`). Do _not_ encode or transform the email, as our plugin will do that for you!
 
-2. *listFields*: many times you want to collect more than just an email address (first/last name, birthday, page pathname).  I like to store this info in React state and pass it in as list fields.  See below.
+1. _email address_: pass in the email as normal (ie, `you@gmail.com`). Do _not_ encode or transform
+   the email, as our plugin will do that for you!
 
-3. I like to save the returned data to React state so I can then display a success/error message to the user.
+2. _listFields_: many times you want to collect more than just an email address (first/last name,
+   birthday, page pathname). I like to store this info in React state and pass it in as list fields.
+   See below.
 
-4. There is a [current known issue (#15)](https://github.com/benjaminhoffman/gatsby-plugin-mailchimp/issues/15) where this plugin does *not work* if the Mailchimp List has [reCAPTCHA enabled](https://mailchimp.com/help/about-recaptcha-for-signup-forms/#Enable-reCAPTCHA/). This setting should be turned off for everything to function properly.
+3. I like to save the returned data to React state so I can then display a success/error message to
+   the user.
 
+4. There is a
+   [current known issue (#15)](https://github.com/benjaminhoffman/gatsby-plugin-mailchimp/issues/15)
+   where this plugin does _not work_ if the Mailchimp List has
+   [reCAPTCHA enabled](https://mailchimp.com/help/about-recaptcha-for-signup-forms/#Enable-reCAPTCHA/).
+   This setting should be turned off for everything to function properly.
 
 ### Create, Remove, or Edit Mailchimp List Fields
-To setup or modify Mailchimp list fields, navigate to your MC list, click "Settings", then click "List fields".  Then add, remove, or edit fields as you wish.  Make sure to update your `addToMailchimp` listFields object after youʼve made changes in Mailchimp.
+
+To setup or modify Mailchimp list fields, navigate to your MC list, click "Settings", then click
+"List fields". Then add, remove, or edit fields as you wish. Make sure to update your
+`addToMailchimp` listFields object after youʼve made changes in Mailchimp.
 
 ![screenshot of Mailchimp list fields settings screen](https://raw.githubusercontent.com/benjaminhoffman/gatsby-plugin-mailchimp/master/img/mailchimp_list_fields.png)
+
+## Contributing
+
+If you'd like to contribute, simply open a PR or open an issue!

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,9 +1,6 @@
 'use strict';
 
-Object.defineProperty(exports, '__esModule', {
-    value: true,
-});
-var onCreateWebpackConfig = function onCreateWebpackConfig(_ref, _ref2) {
+exports.onCreateWebpackConfig = function(_ref, _ref2) {
     var plugins = _ref.plugins,
         actions = _ref.actions;
     var endpoint = _ref2.endpoint;
@@ -15,7 +12,7 @@ var onCreateWebpackConfig = function onCreateWebpackConfig(_ref, _ref2) {
         );
     } else if (endpoint.length < 40) {
         throw new Error(
-            ' gatsby-plugin-mailchimp: donʼt forget to add your MC endpoint to your gatsby-config file. See README for more info.',
+            'gatsby-plugin-mailchimp: donʼt forget to add your MC endpoint to your gatsby-config file. See README for more info.',
         );
     }
 
@@ -27,5 +24,3 @@ var onCreateWebpackConfig = function onCreateWebpackConfig(_ref, _ref2) {
         ],
     });
 };
-
-exports.default = onCreateWebpackConfig;

--- a/index.js
+++ b/index.js
@@ -14,16 +14,20 @@ function _interopRequireDefault(obj) {
     return obj && obj.__esModule ? obj : { default: obj };
 }
 
-/*
- * make a jsonp request to user's mailchimp list
- * url is a concatenated string of user's gatsby-config.js
- * options, along with any MC list fields as query params
+/**
+ * Make a jsonp request to user's mailchimp list
+ *  `param` object avoids CORS issues
+ *  timeout to 3.5s so user isn't waiting forever
+ *  usually occurs w/ privacy plugins enabled
+ *  3.5s is a bit longer than the time it would take on a Slow 3G connection
+ *
+ * @param {String} url - concatenated string of user's gatsby-config.js
+ *  options, along with any MC list fields as query params.
+ *
+ * @return {Promise} - a promise that resolves a data object
+ *  or rejects an error object
  */
 
-// `param` object avoids CORS issues
-// timeout to 3.5s so user isn't waiting forever
-// usually occurs w/ privacy plugins enabled
-// 3.5s is a bit longer than the time it would take on a Slow 3G connection
 var subscribeEmailToMailchimp = function subscribeEmailToMailchimp(url) {
     return new Promise(function(resolve, reject) {
         return (0, _jsonp2.default)(url, { param: 'c', timeout: 3500 }, function(err, data) {
@@ -33,13 +37,15 @@ var subscribeEmailToMailchimp = function subscribeEmailToMailchimp(url) {
     });
 };
 
-/*
- * build a query string of MC list fields
- * ex: '&KEY1=value1&KEY2=value2'
- * FIELDS: toUpperCase because that's what MC requires)
- * GROUPS: keep as lowercase (ex: MC uses group field names as `group[21269]`)
+/**
+ * Build a query string of MC list fields
+ *
+ * @param {Object} fields - a list of mailchimp audience field labels
+ *  and their values. We uppercase because that's what MC requires.
+ *  NOTE: GROUPS stay as lowercase (ex: MC uses group field names as `group[21269]`)
+ *
+ * @return {String} - `&FIELD1=value1&FIELD2=value2&group[21265][2]=group1`
  */
-
 var convertListFields = function convertListFields(fields) {
     var queryParams = '';
     for (var field in fields) {
@@ -53,13 +59,22 @@ var convertListFields = function convertListFields(fields) {
     return queryParams;
 };
 
-/*
- * accept email (String) and additional, optional
- * Mailchimp list fields (Object)
- * then make jsonp req with data
+/**
+ * Subscribe an email address to a Mailchimp email list.
+ * We use ES5 function syntax (instead of arrow) because we need `arguments.length`
+ *
+ * @param {String} email - required; the email address you want to subscribe
+ * @param {Object} fields - optional; add'l info (columns) you want included w/ this subscriber
+ * @param {String} endpointOverride - optional; if you want to override the default MC mailing list
+ *  that's listed in your gatsby-config, pass the list in here
+ *
+ * @return {Object} -
+ *  {
+ *    result: <String>(`success` || `error`)
+ *    msg: <String>(`Thank you for subscribing!` || `The email you entered is not valid.`),
+ *  }
  */
-
-var addToMailchimp = function addToMailchimp(email, fields) {
+var addToMailchimp = function addToMailchimp(email, fields, endpointOverride) {
     var isEmailValid = (0, _emailValidator.validate)(email);
     var emailEncoded = encodeURIComponent(email);
     if (!isEmailValid) {
@@ -69,14 +84,24 @@ var addToMailchimp = function addToMailchimp(email, fields) {
         });
     }
 
-    // generate Mailchimp endpoint for jsonp request
-    // note, we change `/post` to `/post-json`
-    // otherwise, Mailchomp returns an error
     // eslint-disable-next-line no-undef
-    var endpoint = __GATSBY_PLUGIN_MAILCHIMP_ADDRESS__.replace(/\/post/g, '/post-json');
+    var endpoint = __GATSBY_PLUGIN_MAILCHIMP_ADDRESS__;
 
+    // The following tests for whether you passed in a `fields` object. If
+    // there are only two params and the second is a string, then we can safely
+    // assume the second param is a MC mailing list, and not a fields object.
+    if (arguments.length < 3 && typeof fields === 'string') {
+        endpoint = fields;
+    } else if (typeof endpointOverride === 'string') {
+        endpoint = endpointOverride;
+    }
+
+    // Generates MC endpoint for our jsonp request. We have to
+    // change `/post` to `/post-json` otherwise, MC returns an error
+    endpoint = endpoint.replace(/\/post/g, '/post-json');
     var queryParams = '&EMAIL=' + emailEncoded + convertListFields(fields);
     var url = '' + endpoint + queryParams;
+
     return subscribeEmailToMailchimp(url);
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "gatsby-plugin-mailchimp",
     "author": "Benjamin Hoffman <6520022+benjaminhoffman@users.noreply.github.com>",
-    "version": "5.0.1",
+    "version": "5.1.0",
     "description": "A simple, lightweight Gatsby plugin to subscribe email addresses to your Mailchimp list",
     "main": "index.js",
     "license": "MIT",

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,4 +1,4 @@
-const onCreateWebpackConfig = ({ plugins, actions }, { endpoint }) => {
+exports.onCreateWebpackConfig = ({ plugins, actions }, { endpoint }) => {
     const isString = typeof endpoint === 'string';
     if (!isString) {
         throw new Error(
@@ -18,5 +18,3 @@ const onCreateWebpackConfig = ({ plugins, actions }, { endpoint }) => {
         ],
     });
 };
-
-export default onCreateWebpackConfig;


### PR DESCRIPTION
This is a NON BREAKING CHANGE! yay!

You can define your default list within your gatsby-config file but you can also override this value by passing a third value to the `addToMailchimp` method.

https://github.com/benjaminhoffman/gatsby-plugin-mailchimp/issues/13

TODO:
- [ ] update documentation
- [ ] add tests
- [ ] bump minor version & re publish