### PR TITLE
Test field key to start with 'group['

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,8 @@ const convertListFields = fields => {
         if (Object.prototype.hasOwnProperty.call(fields, field)) {
             // If this is a list group, not user field then keep lowercase, as per MC reqs
             // https://github.com/benjaminhoffman/gatsby-plugin-mailchimp/blob/master/README.md#groups
-            const fieldTransformed = field.substring(0, 6) ? field : field.toUpperCase();
+            const fieldTransformed =
+                field.substring(0, 6) === 'group[' ? field : field.toUpperCase();
             queryParams = queryParams.concat(`&${fieldTransformed}=${fields[field]}`);
         }
     }


### PR DESCRIPTION
Fixes #47

BREAKING CHANGE: field keys were claimed to be uppercased before, but weren't. Now they are really transformed to uppercase