### PR TITLE
fixed query

### DIFF
--- a/examples/gatsby-v2/src/components/layout.js
+++ b/examples/gatsby-v2/src/components/layout.js
@@ -8,16 +8,14 @@ import './layout.css';
 
 // eslint-disable-next-line react/prop-types
 const Layout = ({ children }) => (
-    <StaticQuery
+    <siteTitleQueryAndSiteTitleQuery
         query={graphql`
-            query SiteTitleQuery {
-                site {
-                    siteMetadata {
-                        title
-                    }
-                }
-            }
-        `}
+        site {
+          siteMetadata {
+            title
+          }
+        }
+    `}
         render={data => (
             <>
                 <Helmet title={data.site.siteMetadata.title}>


### PR DESCRIPTION
"gatsby": {"version": "2.21.10"}
"gatsby-plugin-mailchimp": {"version": "4.1.0"}

small change so that the compiler doesn't throw this error: 
<img width="947" alt="Screenshot 2020-05-04 at 14 21 31" src="https://user-images.githubusercontent.com/16255463/80965712-53392c00-8e13-11ea-9c24-1ed9923a6279.png">

